### PR TITLE
tulip: use specific idProduct for usb paths

### DIFF
--- a/aosp_e2303.mk
+++ b/aosp_e2303.mk
@@ -45,4 +45,4 @@ PRODUCT_AAPT_PREF_CONFIG := xhdpi
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.sf.lcd_density=320 \
-    ro.usb.pid_suffix=1BA
+    ro.usb.pid_suffix=1C4


### PR DESCRIPTION
from 26.1.A.2.99

extracted kernel.elf and see init.qcom.usb.rc

setprop ro.usb.pid_suffix 1C4

Signed-off-by: David Viteri davidteri91@gmail.com
