### PR TITLE
tulip: don't inherit broadcom wifi conf

### DIFF
--- a/aosp_e2303.mk
+++ b/aosp_e2303.mk
@@ -22,7 +22,6 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/telephony.mk)
 $(call inherit-product, device/sony/kanuti/device.mk)
 $(call inherit-product, vendor/sony/tulip/tulip-vendor.mk)
 $(call inherit-product, frameworks/native/build/phone-xhdpi-2048-dalvik-heap.mk)
-$(call inherit-product, hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk)
 $(call inherit-product-if-exists, prebuilts/chromium/webview_prebuilt.mk)
 $(call inherit-product-if-exists, vendor/google/products/gms.mk)
 


### PR DESCRIPTION
this has qcom chip

Signed-off-by: David Viteri davidteri91@gmail.com
