### PR TITLE
Add device specific frameworks permissions

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -22,6 +22,12 @@ PRODUCT_COPY_FILES := \
     device/sony/tulip/rootdir/system/etc/libnfc-nxp.conf:system/etc/libnfc-nxp.conf \
     device/sony/tulip/rootdir/system/etc/mixer_paths.xml:system/etc/mixer_paths.xml
 
+# Device Specific Permissions
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/handheld_core_hardware.xml:system/etc/permissions/handheld_core_hardware.xml \
+    frameworks/native/data/etc/android.hardware.telephony.gsm.xml:system/etc/permissions/android.hardware.telephony.gsm.xml \
+    frameworks/native/data/etc/android.hardware.sensor.gyroscope.xml:system/etc/permissions/android.hardware.sensor.gyroscope.xml
+
 # Device Init
 PRODUCT_PACKAGES += \
     init.recovery.tulip \


### PR DESCRIPTION
Not all devices have GSM, nor all possible sensors

Signed-off-by: Adam Farden adam@farden.cz
