### PR TITLE
tulip: E2312: override common config_radio_access_family

### DIFF
--- a/aosp_e2312.mk
+++ b/aosp_e2312.mk
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Device path
+DEVICE_PATH := device/sony/tulip
+
 # Inherit from those products. Most specific first.
 $(call inherit-product, device/sony/tulip/aosp_e2303.mk)
+
+# NO LTE RADIO
+DEVICE_PACKAGE_OVERLAYS += \
+    $(DEVICE_PATH)/radio
 
 # DualSim (NO LTE)
 PRODUCT_PROPERTY_OVERRIDES += \

--- a/radio/frameworks/base/core/res/res/values/config.xml
+++ b/radio/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds.  Do not translate. -->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+    <!-- The RadioAccessFamilies supported by the device.
+         Empty is viewed as "all".  Only used on devices which
+         don't support RIL_REQUEST_GET_RADIO_CAPABILITY
+         format is UMTS|LTE|... -->
+    <string translatable="false" name="config_radio_access_family">GSM | GPRS | EDGE | WCDMA</string>
+
+</resources>


### PR DESCRIPTION
E2312 is a not LTE target

Signed-off-by: David Viteri <davidteri91@gmail.com>